### PR TITLE
fix: bezier edges with Center/Closest positions curve instead of collapsing

### DIFF
--- a/src/edges/bezier.rs
+++ b/src/edges/bezier.rs
@@ -29,13 +29,15 @@ fn get_control_with_curvature(
         Position::Top => egui::pos2(x1, y1 - calculate_control_offset(y1 - y2, c)),
         Position::Bottom => egui::pos2(x1, y1 + calculate_control_offset(y2 - y1, c)),
         Position::Center | Position::Closest => {
-            // For center-connected edges, offset the control point toward the
-            // other endpoint along the dominant axis for a natural curve.
             let dx = x2 - x1;
             let dy = y2 - y1;
             let dist = (dx * dx + dy * dy).sqrt().max(1.0);
             let offset = calculate_control_offset(dist, c);
-            egui::pos2(x1 + dx / dist * offset, y1 + dy / dist * offset)
+            let sign = if (x1, y1) < (x2, y2) { 1.0 } else { -1.0 };
+            egui::pos2(
+                x1 + sign * (-dy / dist) * offset,
+                y1 + sign * (dx / dist) * offset,
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- `get_control_with_curvature` in `src/edges/bezier.rs` offset the `Center`/`Closest` control point along the source→target line, so a cubic bezier whose control points lie on the endpoint line collapsed to a straight line.
- Offset perpendicular instead (`-dy/dist`, `dx/dist`). A deterministic `sign` derived from lexicographic `(x,y)` comparison compensates for the caller swapping source/target when computing cp2, so both control points land on the same side of the line and the arc is symmetric — matching React Flow.
- Other edge types (SmoothStep, Step, Straight) are unaffected.

Closes #14

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — 3 passed, 0 failed
- [ ] Visual check: run an example with `EdgeType::Bezier` + `default_source_position: Center` + `default_target_position: Center` — edges now arc instead of straightening