### PR TITLE
feat: dataviz preset and per-node resizable/connectable overrides

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -226,6 +226,22 @@ impl FlowConfig {
         let r = self.node_corner_radius.round().clamp(0.0, 255.0) as u8;
         egui::CornerRadius { nw: r, ne: r, sw: r, se: r }
     }
+
+    /// Read-only data-visualisation preset.
+    ///
+    /// Disables resize handles and connection-drag so nodes stay visually
+    /// stable and users can't create spurious edges.  Nodes remain clickable,
+    /// hoverable, draggable, and selectable; the viewport still pans and
+    /// zooms.  Box-select still requires Shift-drag (the default), so
+    /// unmodified background drag pans rather than starting a rubber-band
+    /// selection.
+    pub fn viz() -> Self {
+        Self {
+            nodes_resizable: false,
+            nodes_connectable: false,
+            ..Default::default()
+        }
+    }
 }
 
 impl Default for FlowConfig {

--- a/src/render/canvas.rs
+++ b/src/render/canvas.rs
@@ -320,7 +320,9 @@ where
         let resize_handle_rects: Vec<egui::Rect> = {
             use crate::interaction::resize::HANDLE_SIZE as RH_SIZE;
             if let Some(rid) = should_show_resize_handles(&self.state.node_lookup) {
-                if let Some(rnode) = self.state.node_lookup.get(&rid) {
+                if let Some(rnode) = self.state.node_lookup.get(&rid)
+                    .filter(|n| n.node.resizable.unwrap_or(self.state.config.nodes_resizable))
+                {
                     let origin = self.state.config.node_origin;
                     let raw = flow_to_screen(rnode.internals.position_absolute, &transform);
                     let nw = rnode.width() * transform.scale;
@@ -520,9 +522,11 @@ where
         // loop may have already set `any_node_dragging`.  If we skipped this
         // block the resize handles would never get registered with egui.
         let is_connecting_now = !matches!(self.state.connection_state, ConnectionState::None);
-        if !is_connecting_now && self.state.config.nodes_resizable {
+        if !is_connecting_now {
             if let Some(resize_node_id) = should_show_resize_handles(&self.state.node_lookup) {
-                if let Some(node) = self.state.node_lookup.get(&resize_node_id) {
+                if let Some(node) = self.state.node_lookup.get(&resize_node_id)
+                    .filter(|n| n.node.resizable.unwrap_or(self.state.config.nodes_resizable))
+                {
                     let origin = self.state.config.node_origin;
                     let raw_origin = flow_to_screen(node.internals.position_absolute, &transform);
                     let nw = node.width() * transform.scale;

--- a/src/types/node.rs
+++ b/src/types/node.rs
@@ -90,8 +90,10 @@ pub struct Node<D = ()> {
     pub draggable: Option<bool>,
     /// Per-node selection override; `None` inherits the global config.
     pub selectable: Option<bool>,
-    /// Per-node connection override; `None` inherits the global config.
+    /// Per-node connection override; `None` inherits [`FlowConfig::nodes_connectable`](crate::config::FlowConfig::nodes_connectable).
     pub connectable: Option<bool>,
+    /// Per-node resize override; `None` inherits [`FlowConfig::nodes_resizable`](crate::config::FlowConfig::nodes_resizable).
+    pub resizable: Option<bool>,
     /// Per-node deletion override; `None` inherits the global config.
     pub deletable: Option<bool>,
     /// Explicit width in flow-space pixels. When `None`, [`measured`](Self::measured) is used.
@@ -155,6 +157,7 @@ pub struct NodeBuilder<D = ()> {
     draggable: Option<bool>,
     selectable: Option<bool>,
     connectable: Option<bool>,
+    resizable: Option<bool>,
     deletable: Option<bool>,
     width: Option<f32>,
     height: Option<f32>,
@@ -188,6 +191,7 @@ impl<D> NodeBuilder<D> {
             draggable: None,
             selectable: None,
             connectable: None,
+            resizable: None,
             deletable: None,
             width: None,
             height: None,
@@ -244,6 +248,22 @@ impl<D> NodeBuilder<D> {
         self
     }
 
+    /// Override whether this node shows resize handles when selected.
+    ///
+    /// Takes precedence over [`FlowConfig::nodes_resizable`](crate::config::FlowConfig::nodes_resizable).
+    pub fn resizable(mut self, v: bool) -> Self {
+        self.resizable = Some(v);
+        self
+    }
+
+    /// Override whether this node can start or accept connection drags.
+    ///
+    /// Takes precedence over [`FlowConfig::nodes_connectable`](crate::config::FlowConfig::nodes_connectable).
+    pub fn connectable(mut self, v: bool) -> Self {
+        self.connectable = Some(v);
+        self
+    }
+
     /// Consume the builder and return the constructed [`Node`].
     ///
     /// # Panics
@@ -265,6 +285,7 @@ impl<D> NodeBuilder<D> {
             draggable: self.draggable,
             selectable: self.selectable,
             connectable: self.connectable,
+            resizable: self.resizable,
             deletable: self.deletable,
             width: self.width,
             height: self.height,


### PR DESCRIPTION
## Summary
- Add `FlowConfig::viz()` read-only preset — disables resize handles and connection-drag while keeping click/hover/drag/select and viewport pan+zoom. Box-select still requires Shift (already the default).
- Add `NodeBuilder::resizable(bool)` and `NodeBuilder::connectable(bool)` per-node overrides stored as `Option<bool>` on `Node<D>`. `None` falls back to the `FlowConfig` default, so existing code is unaffected.
- Resize render sites in `src/render/canvas.rs` now consult `n.node.resizable.unwrap_or(config.nodes_resizable)` via `Option::filter`; `connectable` was already threaded.

Closes #12

## Test plan
- [x] `cargo build` and `cargo build --all-targets` clean
- [x] `cargo test` — 34 unit + 3 doctests pass
- [x] `FlowConfig::default()` behaviour unchanged
- [ ] Try `FlowState::new(FlowConfig::viz())` in an example — no resize handles, no connection previews, pan/zoom still works
- [ ] Mixed graph: set `.resizable(true)` on one node with `FlowConfig::viz()` — only that node shows resize handles