### PR TITLE
feat: optional smooth viewport zoom via zoom_smoothing config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -206,6 +206,15 @@ pub struct FlowConfig {
     /// Cost is O(edges) per frame with a polyline sample per edge; disable
     /// on very large graphs if you don't need hover cues. Default: `true`.
     pub track_edge_hover: bool,
+    /// Smoothing factor applied to scroll / pinch zoom. `0.0` (default) keeps
+    /// the legacy instant-zoom behaviour — each event is applied to the
+    /// viewport on the same frame. Values in `(0.0, 1.0)` interpolate the
+    /// viewport zoom toward an internal target zoom over several frames, so
+    /// high-DPI trackpads and notched wheels feel smoother. `0.85` behaves
+    /// like Figma / xyflow.js; values approaching `1.0` become very slow.
+    /// The zoom-at-pointer anchor is preserved across every interpolation
+    /// step. Values outside `[0.0, 1.0)` are clamped.
+    pub zoom_smoothing: f32,
 }
 
 impl FlowConfig {
@@ -302,6 +311,7 @@ impl Default for FlowConfig {
             edge_label_padding: 3.0,
             cull_offscreen_edges: true,
             track_edge_hover: true,
+            zoom_smoothing: 0.0,
         }
     }
 }

--- a/src/interaction/pan_zoom.rs
+++ b/src/interaction/pan_zoom.rs
@@ -1,4 +1,5 @@
 use crate::config::FlowConfig;
+use crate::state::flow_state::ZoomTarget;
 use crate::types::position::CoordinateExtent;
 use crate::types::viewport::Viewport;
 
@@ -9,6 +10,10 @@ pub(crate) struct PanZoomResult {
     /// If set, the canvas should start an animated zoom toward this screen
     /// position with this factor (used for double-click).
     pub(crate) animate_zoom: Option<(egui::Pos2, f32)>,
+    /// Updated pending smoothed-zoom target (or `None` to clear it). Only
+    /// populated when `config.zoom_smoothing > 0.0` and a scroll / pinch
+    /// event was observed this frame.
+    pub(crate) zoom_target: Option<ZoomTarget>,
 }
 
 /// Handle pan/zoom input from egui.
@@ -28,11 +33,15 @@ pub(crate) fn handle_pan_zoom(
     config: &FlowConfig,
     canvas_rect: egui::Rect,
     suppress_primary_pan: bool,
+    existing_zoom_target: Option<ZoomTarget>,
 ) -> PanZoomResult {
     let mut changed = false;
     let mut animate_zoom: Option<(egui::Pos2, f32)> = None;
+    let smoothing = config.zoom_smoothing.clamp(0.0, 0.999);
+    let smooth = smoothing > 0.0;
+    let mut zoom_target = existing_zoom_target;
 
-    // ── Scroll wheel → instant zoom ──────────────────────────────────────────
+    // ── Scroll wheel → zoom ──────────────────────────────────────────────────
     if config.zoom_on_scroll && response.hovered() {
         let scroll = ui.input(|i| i.raw_scroll_delta.y);
         if scroll != 0.0 {
@@ -42,28 +51,40 @@ pub(crate) fn handle_pan_zoom(
             let pointer = ui
                 .input(|i| i.pointer.hover_pos())
                 .unwrap_or(canvas_rect.center());
-            zoom_toward(viewport, pointer, factor, config.min_zoom, config.max_zoom);
-            clamp_translate(viewport, &config.translate_extent, canvas_rect);
-            changed = true;
+            if smooth {
+                let base = zoom_target.map(|t| t.zoom).unwrap_or(viewport.zoom);
+                let new_target = (base * factor).clamp(config.min_zoom, config.max_zoom);
+                zoom_target = Some(ZoomTarget { pointer, zoom: new_target });
+            } else {
+                zoom_toward(viewport, pointer, factor, config.min_zoom, config.max_zoom);
+                clamp_translate(viewport, &config.translate_extent, canvas_rect);
+                changed = true;
+            }
         }
     }
 
-    // ── Pinch → instant zoom ─────────────────────────────────────────────────
+    // ── Pinch → zoom ─────────────────────────────────────────────────────────
     if config.zoom_on_pinch && response.hovered() {
         let zoom_delta = ui.input(|i| i.zoom_delta());
         if (zoom_delta - 1.0).abs() > f32::EPSILON {
             let pointer = ui
                 .input(|i| i.pointer.hover_pos())
                 .unwrap_or(canvas_rect.center());
-            zoom_toward(
-                viewport,
-                pointer,
-                zoom_delta,
-                config.min_zoom,
-                config.max_zoom,
-            );
-            clamp_translate(viewport, &config.translate_extent, canvas_rect);
-            changed = true;
+            if smooth {
+                let base = zoom_target.map(|t| t.zoom).unwrap_or(viewport.zoom);
+                let new_target = (base * zoom_delta).clamp(config.min_zoom, config.max_zoom);
+                zoom_target = Some(ZoomTarget { pointer, zoom: new_target });
+            } else {
+                zoom_toward(
+                    viewport,
+                    pointer,
+                    zoom_delta,
+                    config.min_zoom,
+                    config.max_zoom,
+                );
+                clamp_translate(viewport, &config.translate_extent, canvas_rect);
+                changed = true;
+            }
         }
     }
 
@@ -124,6 +145,50 @@ pub(crate) fn handle_pan_zoom(
     PanZoomResult {
         changed,
         animate_zoom,
+        zoom_target,
+    }
+}
+
+/// Advance a smoothed zoom toward its stored target by one frame.
+///
+/// `smoothing` is the raw `FlowConfig::zoom_smoothing` value (already clamped
+/// by the caller to `[0.0, 1.0)`). Returns the updated zoom target — `None`
+/// once the viewport has snapped onto the target and the animation is done.
+///
+/// Each step re-anchors the viewport translation to keep the point under the
+/// stored pointer fixed in screen space, mirroring the instant-zoom path.
+pub(crate) fn tick_zoom_smoothing(
+    viewport: &mut Viewport,
+    target: ZoomTarget,
+    smoothing: f32,
+    config: &FlowConfig,
+    canvas_rect: egui::Rect,
+) -> Option<ZoomTarget> {
+    let lerp_factor = (1.0 - smoothing).clamp(0.0, 1.0);
+    let current = viewport.zoom;
+    let desired = target.zoom.clamp(config.min_zoom, config.max_zoom);
+    let next_zoom = current + (desired - current) * lerp_factor;
+    let snap = (next_zoom - desired).abs() < 1e-4 || lerp_factor >= 1.0;
+    let applied_zoom = if snap { desired } else { next_zoom };
+
+    if current > 0.0 {
+        let factor = applied_zoom / current;
+        zoom_toward(
+            viewport,
+            target.pointer,
+            factor,
+            config.min_zoom,
+            config.max_zoom,
+        );
+    } else {
+        viewport.zoom = applied_zoom;
+    }
+    clamp_translate(viewport, &config.translate_extent, canvas_rect);
+
+    if snap {
+        None
+    } else {
+        Some(target)
     }
 }
 

--- a/src/render/canvas.rs
+++ b/src/render/canvas.rs
@@ -23,7 +23,9 @@ use crate::interaction::connection_drag::get_closest_handle;
 use crate::interaction::drag::{
     handle_multi_node_drag, handle_multi_node_drag_end, handle_node_drag,
 };
-use crate::interaction::pan_zoom::{calc_auto_pan, clamp_translate, handle_pan_zoom, zoom_toward};
+use crate::interaction::pan_zoom::{
+    calc_auto_pan, clamp_translate, handle_pan_zoom, tick_zoom_smoothing, zoom_toward,
+};
 use crate::interaction::resize::{render_and_handle_resize, should_show_resize_handles};
 use crate::interaction::selection::get_nodes_inside;
 use crate::render::background::render_background;
@@ -790,10 +792,12 @@ where
                 &self.state.config,
                 canvas_rect,
                 selection_active,
+                self.state.zoom_target,
             );
             if pz.changed {
                 events.set_viewport_changed();
             }
+            self.state.zoom_target = pz.zoom_target;
             // Double-click zoom: start an animated zoom instead of instant
             if let Some((screen_pos, factor)) = pz.animate_zoom {
                 let mut target = self.state.viewport;
@@ -806,6 +810,27 @@ where
                 );
                 self.state.animate_viewport(target, time);
                 events.set_viewport_changed();
+            }
+
+            // ── Smoothed-zoom lerp tick ──────────────────────────────────────
+            if let Some(target) = self.state.zoom_target {
+                let smoothing = self.state.config.zoom_smoothing.clamp(0.0, 0.999);
+                if smoothing > 0.0 {
+                    self.state.zoom_target = tick_zoom_smoothing(
+                        &mut self.state.viewport,
+                        target,
+                        smoothing,
+                        &self.state.config,
+                        canvas_rect,
+                    );
+                    events.set_viewport_changed();
+                    if self.state.zoom_target.is_some() {
+                        ui.ctx().request_repaint();
+                    }
+                } else {
+                    // Smoothing was disabled mid-animation — discard pending target.
+                    self.state.zoom_target = None;
+                }
             }
         }
 

--- a/src/state/flow_state.rs
+++ b/src/state/flow_state.rs
@@ -52,6 +52,21 @@ pub struct FlowState<ND = (), ED = ()> {
     pub has_animated_edges: bool,
     /// Cached z-sorted node IDs. Invalidated on structural changes.
     sorted_ids_cache: Option<Vec<NodeId>>,
+    /// Pending target for smoothed scroll/pinch zoom. `None` when no smoothing
+    /// animation is in progress (or when `config.zoom_smoothing == 0.0`).
+    /// Mutated by the pan/zoom interaction handler and the per-frame lerp in
+    /// [`crate::render::canvas::FlowCanvas`].
+    pub(crate) zoom_target: Option<ZoomTarget>,
+}
+
+/// Pending scroll/pinch zoom target used by the smoothed-zoom path.
+///
+/// The pointer is stored in screen-space so each lerp step can re-anchor the
+/// viewport — keeping the point under the cursor fixed while zoom converges.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ZoomTarget {
+    pub(crate) pointer: egui::Pos2,
+    pub(crate) zoom: f32,
 }
 
 impl<ND: Clone, ED: Clone> FlowState<ND, ED> {
@@ -68,6 +83,7 @@ impl<ND: Clone, ED: Clone> FlowState<ND, ED> {
             viewport_animation: None,
             has_animated_edges: false,
             sorted_ids_cache: None,
+            zoom_target: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `FlowConfig::zoom_smoothing: f32` (default `0.0` → instant, legacy behaviour; `(0.0, 1.0)` → smoothed). Clamped internally to `[0.0, 0.999]` to guarantee convergence.
- New `ZoomTarget { pointer, zoom }` stored on `FlowState` holds the in-flight smoothed target; the pointer is in screen-space so each lerp step re-applies `zoom_toward` at the same cursor anchor, preserving zoom-at-pointer.
- Scroll/pinch with smoothing enabled stacks onto the existing target (rapid wheel ticks accumulate). Mid-animation disable of smoothing clears the pending target cleanly.
- Canvas requests repaint while the lerp is in progress and snaps to target within 1e-4.

Closes #11

## Test plan
- [x] `cargo build` clean, no warnings
- [x] `cargo test` — 34 unit + 3 doctests pass
- [x] With `zoom_smoothing == 0.0` the instant code path is unchanged (no `zoom_target` ever populated)
- [ ] Visual: trackpad pinch with `zoom_smoothing = 0.85` glides instead of snapping
- [ ] Visual: point under cursor stays fixed through the interpolation