### PR TITLE
feat: NodeWidget::shape for correct edge anchoring on custom shapes

### DIFF
--- a/src/edges/positions.rs
+++ b/src/edges/positions.rs
@@ -3,7 +3,7 @@
 use crate::types::edge::EdgePosition;
 use crate::types::handle::{Handle, HandleType};
 use crate::types::node::{InternalNode, NodeId};
-use crate::types::position::Position;
+use crate::types::position::{NodeShape, Position};
 use std::collections::HashMap;
 
 /// Resolve the edge positions from source and target nodes.
@@ -26,9 +26,9 @@ pub fn get_edge_position<D>(
     let source_node = node_lookup.get(source_id)?;
     let target_node = node_lookup.get(target_id)?;
 
-    let (sx, sy, source_pos) = if let Some(anchor) = source_anchor {
+    let (sx, sy, source_pos, source_fallback) = if let Some(anchor) = source_anchor {
         let pt = anchor.resolve(source_node.rect());
-        (pt.x, pt.y, anchor.side)
+        (pt.x, pt.y, anchor.side, false)
     } else {
         get_handle_position_for_node(
             source_node,
@@ -37,9 +37,9 @@ pub fn get_edge_position<D>(
             default_source_pos,
         )
     };
-    let (tx, ty, target_pos) = if let Some(anchor) = target_anchor {
+    let (tx, ty, target_pos, target_fallback) = if let Some(anchor) = target_anchor {
         let pt = anchor.resolve(target_node.rect());
-        (pt.x, pt.y, anchor.side)
+        (pt.x, pt.y, anchor.side, false)
     } else {
         get_handle_position_for_node(
             target_node,
@@ -64,6 +64,20 @@ pub fn get_edge_position<D>(
     };
     let (tx, ty) = if target_pos == Position::Closest && target_anchor.is_none() {
         reproject_to_side(target_node, resolved_target)
+    } else {
+        (tx, ty)
+    };
+
+    // Shape-aware perimeter intersection: when the endpoint came from the
+    // no-explicit-handle fallback and the node declares a non-Rect shape,
+    // anchor on the real silhouette along the centre-to-centre line.
+    let (sx, sy) = if source_fallback {
+        shape_perimeter_point(source_node, target_center).unwrap_or((sx, sy))
+    } else {
+        (sx, sy)
+    };
+    let (tx, ty) = if target_fallback {
+        shape_perimeter_point(target_node, source_center).unwrap_or((tx, ty))
     } else {
         (tx, ty)
     };
@@ -95,7 +109,7 @@ fn get_handle_position_for_node<D>(
     handle_type: HandleType,
     handle_id: Option<&str>,
     default_pos: Position,
-) -> (f32, f32, Position) {
+) -> (f32, f32, Position, bool) {
     let handles = match handle_type {
         HandleType::Source => &node.internals.handle_bounds.source,
         HandleType::Target => &node.internals.handle_bounds.target,
@@ -111,7 +125,7 @@ fn get_handle_position_for_node<D>(
     if let Some(h) = handle {
         let pos = h.position;
         let abs = get_handle_absolute_position(node, h);
-        (abs.x, abs.y, pos)
+        (abs.x, abs.y, pos, false)
     } else {
         // Fallback: center of the node side (or node center for Position::Center/Closest)
         let rect = node.rect();
@@ -122,8 +136,111 @@ fn get_handle_position_for_node<D>(
             Position::Right => (rect.max.x, rect.center().y),
             Position::Center | Position::Closest => (rect.center().x, rect.center().y),
         };
-        (x, y, default_pos)
+        (x, y, default_pos, true)
     }
+}
+
+/// Intersect the line from `node`'s centre to `other_center` with the node's
+/// declared shape silhouette, returning the flow-space point on the perimeter.
+/// Returns `None` for [`NodeShape::Rect`] (caller keeps the side-centre anchor).
+fn shape_perimeter_point<D>(
+    node: &InternalNode<D>,
+    other_center: egui::Pos2,
+) -> Option<(f32, f32)> {
+    let rect = node.rect();
+    let center = rect.center();
+    let dir = other_center - center;
+    let len = dir.length();
+    if len < f32::EPSILON {
+        return None;
+    }
+    let unit = dir / len;
+    match node.internals.shape {
+        NodeShape::Rect => None,
+        NodeShape::Circle { radius } => {
+            let p = center + unit * radius.max(0.0);
+            Some((p.x, p.y))
+        }
+        NodeShape::RoundedRect { rounding } => {
+            rounded_rect_intersect(rect, other_center, rounding).map(|p| (p.x, p.y))
+        }
+    }
+}
+
+/// Intersection of the ray from `rect.center()` toward `other_center` with a
+/// rounded-rectangle perimeter (flat sides + quarter-circle corners).
+fn rounded_rect_intersect(
+    rect: egui::Rect,
+    other_center: egui::Pos2,
+    rounding: f32,
+) -> Option<egui::Pos2> {
+    let center = rect.center();
+    let dir = other_center - center;
+    let len = dir.length();
+    if len < f32::EPSILON {
+        return None;
+    }
+    let half_w = rect.width() * 0.5;
+    let half_h = rect.height() * 0.5;
+    let r = rounding.max(0.0).min(half_w.min(half_h));
+
+    // Ray-rect hit point (as if corners were sharp).
+    let tx = if dir.x.abs() > f32::EPSILON {
+        half_w / dir.x.abs()
+    } else {
+        f32::INFINITY
+    };
+    let ty = if dir.y.abs() > f32::EPSILON {
+        half_h / dir.y.abs()
+    } else {
+        f32::INFINITY
+    };
+    let t = tx.min(ty);
+    let hit = center + dir * t;
+
+    if r <= 0.0 {
+        return Some(hit);
+    }
+
+    // Is the flat-side hit inside the rounded corner's exclusion zone?
+    let corner_cx = if hit.x >= center.x {
+        rect.max.x - r
+    } else {
+        rect.min.x + r
+    };
+    let corner_cy = if hit.y >= center.y {
+        rect.max.y - r
+    } else {
+        rect.min.y + r
+    };
+    let in_corner_x = (hit.x - center.x).abs() > (corner_cx - center.x).abs();
+    let in_corner_y = (hit.y - center.y).abs() > (corner_cy - center.y).abs();
+    if !(in_corner_x && in_corner_y) {
+        return Some(hit);
+    }
+
+    // Solve for intersection with the quarter-circle corner centred at
+    // (corner_cx, corner_cy) with radius r. Ray: center + u * dir, u > 0.
+    let ox = center.x - corner_cx;
+    let oy = center.y - corner_cy;
+    let a = dir.x * dir.x + dir.y * dir.y;
+    let b = 2.0 * (ox * dir.x + oy * dir.y);
+    let c = ox * ox + oy * oy - r * r;
+    let disc = b * b - 4.0 * a * c;
+    if disc < 0.0 || a < f32::EPSILON {
+        return Some(hit);
+    }
+    let sqrt_disc = disc.sqrt();
+    let u1 = (-b - sqrt_disc) / (2.0 * a);
+    let u2 = (-b + sqrt_disc) / (2.0 * a);
+    let u = [u1, u2]
+        .into_iter()
+        .filter(|v| *v > 0.0)
+        .fold(f32::INFINITY, f32::min);
+    if !u.is_finite() {
+        return Some(hit);
+    }
+    Some(center + dir * u)
 }
 
 /// Get absolute position of a handle center.
@@ -196,4 +313,74 @@ pub fn project_to_border(
     };
 
     EdgeAnchor { side, t }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::node::{InternalNode, Node, NodeHandleBounds, NodeInternals};
+
+    fn make_node(x: f32, y: f32, w: f32, h: f32, shape: NodeShape) -> InternalNode<()> {
+        let mut node: Node<()> = Node::builder("n").build();
+        node.position = egui::pos2(x, y);
+        node.width = Some(w);
+        node.height = Some(h);
+        InternalNode {
+            node,
+            internals: NodeInternals {
+                position_absolute: egui::pos2(x, y),
+                z: 0,
+                handle_bounds: NodeHandleBounds::default(),
+                shape,
+            },
+        }
+    }
+
+    #[test]
+    fn circle_shape_anchors_on_perimeter() {
+        let n = make_node(0.0, 0.0, 100.0, 100.0, NodeShape::Circle { radius: 50.0 });
+        // Target to the right: intersection is at center + (50, 0)
+        let p = shape_perimeter_point(&n, egui::pos2(200.0, 50.0)).unwrap();
+        assert!((p.0 - 100.0).abs() < 1e-3, "x={}", p.0);
+        assert!((p.1 - 50.0).abs() < 1e-3, "y={}", p.1);
+    }
+
+    #[test]
+    fn rect_shape_returns_none_so_caller_keeps_side_center() {
+        let n = make_node(0.0, 0.0, 100.0, 100.0, NodeShape::Rect);
+        assert!(shape_perimeter_point(&n, egui::pos2(200.0, 50.0)).is_none());
+    }
+
+    #[test]
+    fn rounded_rect_flat_side_hits_rect_edge() {
+        let n = make_node(
+            0.0,
+            0.0,
+            100.0,
+            100.0,
+            NodeShape::RoundedRect { rounding: 10.0 },
+        );
+        // Straight right along centreline → hits right edge at (100, 50), not the corner arc.
+        let p = shape_perimeter_point(&n, egui::pos2(200.0, 50.0)).unwrap();
+        assert!((p.0 - 100.0).abs() < 1e-3);
+        assert!((p.1 - 50.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn rounded_rect_diagonal_hits_corner_arc() {
+        let n = make_node(
+            0.0,
+            0.0,
+            100.0,
+            100.0,
+            NodeShape::RoundedRect { rounding: 10.0 },
+        );
+        // Toward the top-right corner. The arc centre is (90, 10), radius 10.
+        // The intersection must satisfy (x-90)^2 + (y-10)^2 = 100.
+        let p = shape_perimeter_point(&n, egui::pos2(200.0, -100.0)).unwrap();
+        let dx = p.0 - 90.0;
+        let dy = p.1 - 10.0;
+        let d2 = dx * dx + dy * dy;
+        assert!((d2 - 100.0).abs() < 1e-2, "d^2 = {}", d2);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,9 @@ pub use types::handle::{Handle, HandleType, NodeHandle};
 pub use types::node::{
     InternalNode, Node, NodeBuilder, NodeExtent, NodeHandleBounds, NodeId, NodeInternals,
 };
-pub use types::position::{CoordinateExtent, Dimensions, NodeOrigin, Position, SnapGrid, Transform};
+pub use types::position::{
+    CoordinateExtent, Dimensions, NodeOrigin, NodeShape, Position, SnapGrid, Transform,
+};
 pub use types::viewport::{PanOnScrollMode, SelectionMode, Viewport};
 
 // State
@@ -249,7 +251,7 @@ pub mod prelude {
     };
     pub use crate::types::handle::{HandleType, NodeHandle};
     pub use crate::types::node::{Node, NodeExtent, NodeId};
-    pub use crate::types::position::{CoordinateExtent, Dimensions, Position, Transform};
+    pub use crate::types::position::{CoordinateExtent, Dimensions, NodeShape, Position, Transform};
     pub use crate::types::viewport::{SelectionMode, Viewport};
 
     pub use crate::state::flow_state::FlowState;

--- a/src/render/canvas.rs
+++ b/src/render/canvas.rs
@@ -208,6 +208,11 @@ where
 
         let transform = self.state.viewport.to_transform();
 
+        // ── Populate per-node shape from the widget for edge-anchor routing ──
+        for internal in self.state.node_lookup.values_mut() {
+            internal.internals.shape = self.node_widget.shape(&internal.node);
+        }
+
         // ── 1. Background ────────────────────────────────────────────────────
         render_background(
             &painter,

--- a/src/render/node_renderer.rs
+++ b/src/render/node_renderer.rs
@@ -6,7 +6,7 @@
 
 use crate::config::FlowConfig;
 use crate::types::node::Node;
-use crate::types::position::Transform;
+use crate::types::position::{NodeShape, Transform};
 
 /// Trait for custom node rendering.
 pub trait NodeWidget<D> {
@@ -27,6 +27,14 @@ pub trait NodeWidget<D> {
         hovered: bool,
         transform: &Transform,
     );
+
+    /// Return the node's real painted silhouette. Used by edge routing to
+    /// compute the correct perimeter-intersection anchor when no explicit
+    /// handle is defined. Default returns [`NodeShape::Rect`] (the historical
+    /// behaviour of anchoring edges to points on the axis-aligned bounding box).
+    fn shape(&self, _node: &Node<D>) -> NodeShape {
+        NodeShape::Rect
+    }
 }
 
 /// Apply `config.node_bg_opacity` to a colour's alpha channel.

--- a/src/state/flow_state.rs
+++ b/src/state/flow_state.rs
@@ -192,6 +192,7 @@ impl<ND: Clone, ED: Clone> FlowState<ND, ED> {
                     position_absolute: node.position,
                     z: node.z_index.unwrap_or(0),
                     handle_bounds,
+                    shape: crate::types::position::NodeShape::Rect,
                 },
                 node: node.clone(),
             };

--- a/src/state/node_lookup.rs
+++ b/src/state/node_lookup.rs
@@ -209,6 +209,7 @@ mod tests {
                         position_absolute: egui::pos2(x, y),
                         z,
                         handle_bounds: NodeHandleBounds::default(),
+                        shape: crate::types::position::NodeShape::Rect,
                     },
                 },
             );

--- a/src/types/node.rs
+++ b/src/types/node.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use super::handle::{Handle, NodeHandle};
-use super::position::{CoordinateExtent, Dimensions, NodeOrigin, Position};
+use super::position::{CoordinateExtent, Dimensions, NodeOrigin, NodeShape, Position};
 
 /// Unique identifier for a node in the graph.
 ///
@@ -297,6 +297,10 @@ pub struct NodeInternals {
     pub z: i32,
     /// Resolved handle geometry.
     pub handle_bounds: NodeHandleBounds,
+    /// Resolved geometric shape (from [`crate::render::node_renderer::NodeWidget::shape`]),
+    /// used by edge routing to compute perimeter-intersection anchor points
+    /// when no explicit handle is defined.
+    pub shape: NodeShape,
 }
 
 /// A node paired with its computed internal state.

--- a/src/types/position.rs
+++ b/src/types/position.rs
@@ -67,6 +67,37 @@ impl Position {
     }
 }
 
+/// Geometric shape of a node's rendered body, used by edge routing to compute
+/// the correct perimeter-intersection anchor point when no explicit handle is
+/// defined.
+///
+/// Default ([`NodeShape::Rect`]) preserves the historical behaviour of
+/// anchoring edges to points on the node's axis-aligned bounding box.  Return
+/// a different variant from [`NodeWidget::shape`](crate::render::node_renderer::NodeWidget::shape)
+/// when the painted node is not a rectangle (e.g. circle, pill, diamond) so
+/// that edges terminate on the real silhouette.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NodeShape {
+    /// Axis-aligned rectangle matching the node's bounding box. Current default behaviour.
+    Rect,
+    /// Circle centred on the bounding-box centre with the given flow-space radius.
+    Circle {
+        /// Circle radius in flow-space units.
+        radius: f32,
+    },
+    /// Rounded rectangle with the given corner radius in flow-space units.
+    RoundedRect {
+        /// Corner radius in flow-space units.
+        rounding: f32,
+    },
+}
+
+impl Default for NodeShape {
+    fn default() -> Self {
+        NodeShape::Rect
+    }
+}
+
 /// Dimensions of a node or element.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
## Summary
- Add `NodeShape { Rect, Circle { radius }, RoundedRect { rounding } }` enum (exported from crate root and prelude).
- Add default `NodeWidget::shape(&self, &Node<D>) -> NodeShape` method returning `NodeShape::Rect` — non-breaking for existing widget implementors.
- Canvas populates `InternalNode.internals.shape` once per frame from the widget before edge rendering.
- `get_edge_position` threads a `fallback` flag so shape-perimeter intersection only applies at endpoints without an explicit handle. Existing handle-using graphs render byte-identically.
- Circle: analytical intersection. RoundedRect: ray-rect hit with quarter-circle corner-arc quadratic solve. Rect: returns `None` → caller keeps the historical side-centre anchor.
- 4 new unit tests (`circle_shape_anchors_on_perimeter`, `rect_shape_returns_none_so_caller_keeps_side_center`, `rounded_rect_flat_side_hits_rect_edge`, `rounded_rect_diagonal_hits_corner_arc`).

Closes #13

## Test plan
- [x] `cargo build` clean, `cargo build --all-targets` clean
- [x] `cargo test` — 38 unit tests, doctests green
- [x] Existing widgets render identically (default `shape()` returns `Rect`, which returns `None` from the perimeter function)
- [ ] Visual: a circle-shaped `NodeWidget` returning `Circle { radius }` anchors incoming edges on the circle silhouette, not the bounding-box edge
- [ ] Visual: a pill-shaped widget with `RoundedRect { rounding }` — edges land on flat sides or corner arcs correctly